### PR TITLE
Command line launch options

### DIFF
--- a/HDRImageViewer/App.xaml.cpp
+++ b/HDRImageViewer/App.xaml.cpp
@@ -14,6 +14,7 @@
 
 using namespace HDRImageViewer;
 
+using namespace concurrency;
 using namespace Platform;
 using namespace Windows::ApplicationModel;
 using namespace Windows::ApplicationModel::Activation;
@@ -63,6 +64,115 @@ void App::OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEvent
     // Place the page in the current window and ensure that it is active.
     Window::Current->Content = m_directXPage;
     Window::Current->Activate();
+}
+
+// Invoked when app is activated for special purposes such as via command line.
+void App::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args)
+{
+    if (args->Kind == ActivationKind::CommandLineLaunch)
+    {
+        auto cmd = static_cast<CommandLineActivatedEventArgs^>(args);
+        auto rawArgs = cmd->Operation->Arguments;
+
+        std::wstringstream argsStream;
+        argsStream << rawArgs->Data();
+
+        bool useFullscreen = false;
+        bool hideUI = false;
+        String^ fullFilename;
+
+        std::wstring arg;
+        std::getline(argsStream, arg, L' '); // First argument is the executable name.
+        while (std::getline(argsStream, arg, L' '))
+        {
+            if (arg.size() == 0)
+            {
+                // Second argument always is L"" for some reason.
+                continue;
+            }
+
+            const WCHAR fullscreenArg[] = L"-f";
+            if (!wcsncmp(fullscreenArg, arg.c_str(), ARRAYSIZE(fullscreenArg) - 1))
+            {
+                useFullscreen = true;
+                continue;
+            }
+
+            const WCHAR suppressUIArg[] = L"-h";
+            if (!wcsncmp(suppressUIArg, arg.c_str(), ARRAYSIZE(suppressUIArg) - 1))
+            {
+                hideUI = true;
+                continue;
+            }
+
+            const WCHAR inputArg[] = L"-input:";
+            const UINT countInputArg = ARRAYSIZE(inputArg) - 1;
+            if (!wcsncmp(inputArg, arg.c_str(), countInputArg) && wcslen(arg.c_str()) > countInputArg)
+            {
+                std::wstringstream path;
+                path
+                    << cmd->Operation->CurrentDirectoryPath->Data()
+                    << L"\\"
+                    << arg.substr(countInputArg);
+
+                fullFilename = ref new String(path.str().c_str());
+                continue;
+            }
+
+            std::wstringstream help;
+            help
+                << L"-f\n\tStart in fullscreen mode\n"
+                << L"\tNOTE: This only applies on next startup.\n\n"
+                << L"-h\n\tStart with UI hidden\n\n"
+                << L"-input:[filename]\n\tLoad [filename]\n"
+                << L"\tNOTE: The file must be in the current working directory,\n"
+                << L"\tas HDRImageViewer only has access to this directory.";
+
+            Platform::String^ helpString = ref new String(help.str().c_str());
+
+            auto usageCtrl = ref new Windows::UI::Xaml::Controls::ContentDialog();
+            usageCtrl->Title = L"HDRImageViewer command line usage";
+            usageCtrl->Content = helpString;
+            usageCtrl->CloseButtonText = L"OK";
+            usageCtrl->FontFamily = ref new Windows::UI::Xaml::Media::FontFamily(L"Consolas");
+            usageCtrl->ShowAsync();
+
+            break;
+        }
+
+        if (m_directXPage == nullptr)
+        {
+            m_directXPage = ref new DirectXPage();
+        }
+
+        m_directXPage->SetUIFullscreen(useFullscreen);
+        m_directXPage->SetUIHidden(hideUI);
+
+        // Place the page in the current window and ensure that it is active.
+        Window::Current->Content = m_directXPage;
+        Window::Current->Activate();
+
+        if (fullFilename != nullptr)
+        {
+            try
+            {
+                create_task(StorageFile::GetFileFromPathAsync(fullFilename)).then([=](StorageFile^ file) {
+                    if (file != nullptr)
+                    {
+                        m_directXPage->LoadImage(file);
+                    }
+                    });
+            }
+            catch (Platform::Exception^ e)
+            {
+                auto fileCtrl = ref new Windows::UI::Xaml::Controls::ContentDialog();
+                fileCtrl->Title = L"Error loading the specified file";
+                fileCtrl->Content = e->Message;
+                fileCtrl->CloseButtonText = L"OK";
+                fileCtrl->ShowAsync();
+            }
+        }
+    }
 }
 
 // Invoked when the app is launched via the file type association for which the app has registered.

--- a/HDRImageViewer/App.xaml.h
+++ b/HDRImageViewer/App.xaml.h
@@ -24,6 +24,7 @@ namespace HDRImageViewer
     public:
         App();
         virtual void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e) override;
+        virtual void OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args) override;
         virtual void OnFileActivated(Windows::ApplicationModel::Activation::FileActivatedEventArgs^ e) override;
 
     private:

--- a/HDRImageViewer/DirectXPage.xaml.cpp
+++ b/HDRImageViewer/DirectXPage.xaml.cpp
@@ -278,6 +278,32 @@ void DirectXPage::LoadImage(_In_ StorageFile^ imageFile)
     }, task_continuation_context::use_current());
 }
 
+void DirectXPage::SetUIHidden(bool value)
+{
+    if (value == false)
+    {
+        ControlsPanel->Visibility = Windows::UI::Xaml::Visibility::Visible;
+    }
+    else
+    {
+        ControlsPanel->Visibility = Windows::UI::Xaml::Visibility::Collapsed;
+    }
+}
+
+void DirectXPage::SetUIFullscreen(bool value)
+{
+    if (value == false)
+    {
+        ApplicationView::GetForCurrentView()->ExitFullScreenMode();
+        ApplicationView::GetForCurrentView()->PreferredLaunchWindowingMode = ApplicationViewWindowingMode::Auto;
+    }
+    else
+    {
+        ApplicationView::GetForCurrentView()->TryEnterFullScreenMode();
+        ApplicationView::GetForCurrentView()->PreferredLaunchWindowingMode = ApplicationViewWindowingMode::FullScreen;
+    }
+}
+
 void DirectXPage::ExportImageToSdr(_In_ Windows::Storage::StorageFile ^ file)
 {
     GUID wicFormat = {};
@@ -538,11 +564,11 @@ void DirectXPage::OnKeyUp(_In_ CoreWindow^ sender, _In_ KeyEventArgs^ args)
     {
         if (Windows::UI::Xaml::Visibility::Collapsed == ControlsPanel->Visibility)
         {
-            ControlsPanel->Visibility = Windows::UI::Xaml::Visibility::Visible;
+            SetUIHidden(false);
         }
         else
         {
-            ControlsPanel->Visibility = Windows::UI::Xaml::Visibility::Collapsed;
+            SetUIHidden(true);
         }
     }
     else if (VirtualKey::F == args->VirtualKey ||
@@ -550,19 +576,16 @@ void DirectXPage::OnKeyUp(_In_ CoreWindow^ sender, _In_ KeyEventArgs^ args)
     {
         if (ApplicationView::GetForCurrentView()->IsFullScreenMode)
         {
-            ApplicationView::GetForCurrentView()->ExitFullScreenMode();
+            SetUIFullscreen(false);
         }
         else
         {
-            ApplicationView::GetForCurrentView()->TryEnterFullScreenMode();
+            SetUIFullscreen(true);
         }
     }
     else if (VirtualKey::Escape == args->VirtualKey)
     {
-        if (ApplicationView::GetForCurrentView()->IsFullScreenMode)
-        {
-            ApplicationView::GetForCurrentView()->ExitFullScreenMode();
-        }
+        SetUIFullscreen(false);
     }
 }
 

--- a/HDRImageViewer/DirectXPage.xaml.h
+++ b/HDRImageViewer/DirectXPage.xaml.h
@@ -36,6 +36,9 @@ namespace HDRImageViewer
         void LoadDefaultImage();
         void LoadImage(_In_ Windows::Storage::StorageFile^ imageFile);
 
+        void SetUIFullscreen(bool value);
+        void SetUIHidden(bool value);
+
         property RenderOptionsViewModel^ ViewModel
         {
             RenderOptionsViewModel^ get() { return m_renderOptionsViewModel; }

--- a/HDRImageViewer/Package.appxmanifest
+++ b/HDRImageViewer/Package.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4" IgnorableNamespaces="uap mp">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap mp uap5">
   <Identity Name="24700lepusmagnum.HDRandWCGImageViewer" Publisher="CN=DC282004-FA5B-46E0-8880-6E68BFA41465" Version="1.0.5.0" />
   <mp:PhoneIdentity PhoneProductId="a87b377f-cb50-442c-a4e8-871dca2f8432" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -80,6 +80,14 @@
             </uap:SupportedFileTypes>
           </uap:FileTypeAssociation>
         </uap:Extension>
+        <uap5:Extension
+        Category="windows.appExecutionAlias"
+        Executable="HDRImageViewer.exe"
+        EntryPoint="HDRImageViewer.App">
+              <uap5:AppExecutionAlias>
+                  <uap5:ExecutionAlias Alias="HDRImageViewer.exe" />
+              </uap5:AppExecutionAlias>
+          </uap5:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/HDRImageViewer/pch.h
+++ b/HDRImageViewer/pch.h
@@ -17,6 +17,7 @@
 #include <collection.h>
 #include <concrt.h>
 #include <memory>
+#include <PathCch.h>
 #include <ppltasks.h>
 #include <shcore.h>
 #include <string>


### PR DESCRIPTION
Adds support for launching from the command line.

## Command line usage
You should invoke HDRImageViewer from the directory containing the image you wish to load - UWP apps launched from a command line only have access to files within the working directory.
### Parameters
`-f` Start in fullscreen mode
`-h` Start with UI hidden
`-input:[filename]` Load [filename]
**Note: Filename must be relative to the current working directory as HDRImageViewer only has access to that directory.**
### Example
`HDRImageViewer.exe -f -h -input:myimage.jxr`