### PR TITLE
add a gamut mapping effect to the pipeline

### DIFF
--- a/DXRenderer/DXRenderer.vcxproj
+++ b/DXRenderer/DXRenderer.vcxproj
@@ -286,6 +286,7 @@
     <ClInclude Include="ImageExporter.h" />
     <ClInclude Include="ImageInfo.h" />
     <ClInclude Include="ImageLoader.h" />
+    <ClInclude Include="Matrix.h" />
     <ClInclude Include="RenderEffects\LuminanceHeatmapEffect.h" />
     <ClInclude Include="MagicConstants.h" />
     <ClInclude Include="pch.h" />

--- a/DXRenderer/DXRenderer.vcxproj.filters
+++ b/DXRenderer/DXRenderer.vcxproj.filters
@@ -74,6 +74,7 @@
       <Filter>RenderEffects</Filter>
     </ClInclude>
     <ClInclude Include="RenderOptions.h" />
+    <ClInclude Include="Matrix.h" />
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="RenderEffects\LuminanceHeatmapEffect.hlsl">

--- a/DXRenderer/HDRImageViewerRenderer.h
+++ b/DXRenderer/HDRImageViewerRenderer.h
@@ -14,6 +14,7 @@
 #include "RenderEffects\SphereMapEffect.h"
 #include "RenderOptions.h"
 #include "ImageLoader.h"
+#include "Matrix.h"
 
 namespace DXRenderer
 {
@@ -58,7 +59,8 @@ namespace DXRenderer
             RenderEffectKind effect,
             float brightnessAdjustment,
             float dispMaxCllOverride,
-            Windows::Graphics::Display::AdvancedColorInfo^ acInfo
+            Windows::Graphics::Display::AdvancedColorInfo^ acInfo,
+            bool constrainGamut
             );
 
         ImageInfo LoadImageFromWic(_In_ Windows::Storage::Streams::IRandomAccessStream^ imageStream, ImageLoaderOptions options);
@@ -85,6 +87,7 @@ namespace DXRenderer
         void UpdateImageTransformState();
         void ComputeHdrMetadata();
         void EmitHdrMetadata();
+        void UpdateGamutTransforms();
 
         float GetBestDispMaxLuminance();
 
@@ -103,6 +106,8 @@ namespace DXRenderer
         Microsoft::WRL::ComPtr<ID2D1Effect>                     m_sphereMapEffect;
         Microsoft::WRL::ComPtr<ID2D1Effect>                     m_histogramPrescale;
         Microsoft::WRL::ComPtr<ID2D1Effect>                     m_histogramEffect;
+        Microsoft::WRL::ComPtr<ID2D1Effect>                     m_mapGamutToPanel;
+        Microsoft::WRL::ComPtr<ID2D1Effect>                     m_mapGamutToScRGB;
         Microsoft::WRL::ComPtr<ID2D1Effect>                     m_finalOutput;
 
         std::vector<float>                                      m_renderTargetCpuPixels;
@@ -120,5 +125,7 @@ namespace DXRenderer
         bool                                                    m_isComputeSupported;
         float                                                   m_dispMaxCLLOverride;
         bool                                                    m_enableTargetCpuReadback;
+
+        bool                                                    m_constrainGamut;
     };
 }

--- a/DXRenderer/Matrix.h
+++ b/DXRenderer/Matrix.h
@@ -1,0 +1,98 @@
+#pragma once
+#include <vector>
+#include <cassert>
+struct Matrix
+{
+    Matrix(size_t x, size_t y) : X(x), Y(y)
+    {
+        M.resize(x * y);
+    }
+
+    double& Index(size_t i_x, size_t i_y)
+    {
+        return M[i_y * X + i_x];
+    }
+
+    Matrix operator*(const Matrix& rhs)
+    {
+        assert(X == rhs.Y);
+        Matrix ret(rhs.X, Y);
+
+        size_t x, y;
+        for (size_t i = 0; i < ret.M.size(); i++)
+        {
+            x = i % ret.X;
+            y = i / ret.X;
+
+            ret.M[i] = 0;
+
+            for (size_t r = 0; r < X; r++)
+            {
+                ret.M[i] += M[X * y + r] * rhs.M[rhs.X * r + x];
+            }
+        }
+
+        return ret;
+    }
+
+    Matrix SubMatrix(size_t x_start, size_t y_start, size_t width, size_t height)
+    {
+        assert((x_start + width) <= X && (y_start + height) <= Y);
+
+        Matrix ret(width, height);
+        size_t index = 0;
+
+        for (size_t y = y_start; y < y_start + height; y++)
+        {
+            for (size_t x = x_start; x < x_start + width; x++)
+            {
+                ret.M[index++] = M[y * X + x % X];
+            }
+        }
+
+        return ret;
+    }
+
+    double Determinant()
+    {
+        assert(X == Y);
+
+        // I'm lazy and only worrying about the 3x3 case right now.
+        assert(Y == 3);
+
+        double ret = 0;
+
+        for (size_t x = 0; x < X; x++)
+        {
+            ret += (Index(0, x) *
+                (Index(1, (x + 1) % 3) * Index(2, (x + 2) % 3) -
+                    Index(1, (x + 2) % 3) * Index(2, (x + 1) % 3)));
+        }
+
+        return ret;
+    }
+
+    Matrix Invert()
+    {
+        // Basically all color matrices are 3x3 - I'm only worrying about that here
+        assert(X == Y && X == 3);
+
+        Matrix ret(3, 3);
+        double det = Determinant();
+
+        assert(det > 0);
+
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
+                ret.Index(i, j) = ((Index((j + 1) % 3, (i + 1) % 3) * Index((j + 2) % 3, (i + 2) % 3)) - (Index((j + 1) % 3, (i + 2) % 3) * Index((j + 2) % 3, (i + 1) % 3))) / det;
+            }
+        }
+
+        return ret;
+    }
+
+    const size_t X, Y;
+    std::vector<double> M;
+};

--- a/HDRImageViewerCS/MainPage.xaml
+++ b/HDRImageViewerCS/MainPage.xaml
@@ -17,6 +17,8 @@
         <KeyboardAccelerator Key="F11" Invoked="ToggleFullscreenInvoked" />
         <KeyboardAccelerator Key="Escape" Invoked="EscapeFullscreenInvoked" />
         <KeyboardAccelerator Key="F1" Modifiers="Control" Invoked="ToggleExperimentalToolsInvoked" />
+        <KeyboardAccelerator Key="G" Invoked="ToggleGamutMap" />
+        <KeyboardAccelerator Key="P" Invoked="ToggleProfileOverride" />
     </Page.KeyboardAccelerators>
 
     <Grid>
@@ -110,10 +112,16 @@
             <TextBlock Style="{StaticResource InfoLine}" x:Name="DisplayACState">Kind:</TextBlock>
             <TextBlock Style="{StaticResource InfoLine}" x:Name="DisplayPeakLuminance">Peak luminance:</TextBlock>
             <MenuFlyoutSeparator />
+            <TextBlock Style="{StaticResource SectionTitle}">Current Options</TextBlock>
+            <TextBlock Style="{StaticResource InfoLine}" x:Name="Gamutmap">Constrain image gamut: on</TextBlock>
+            <TextBlock Style="{StaticResource InfoLine}" x:Name="ProfileOverride">Use display color profile: on (SDR-only)</TextBlock>
+            <MenuFlyoutSeparator />
             <TextBlock Style="{StaticResource SectionTitle}">Keyboard shortcuts</TextBlock>
             <TextBlock Style="{StaticResource InfoLine}"><Bold>H:</Bold> Toggle UI</TextBlock>
             <TextBlock Style="{StaticResource InfoLine}"><Bold>F, F11:</Bold> Toggle fullscreen</TextBlock>
             <TextBlock Style="{StaticResource InfoLine}"><Bold>Esc:</Bold> Exit fullscreen</TextBlock>
+            <TextBlock Style="{StaticResource InfoLine}"><Bold>G:</Bold> Toggle gamut constraints</TextBlock>
+            <TextBlock Style="{StaticResource InfoLine}"><Bold>P:</Bold> Toggle display profile override (SDR-only)</TextBlock>
             <StackPanel x:Name="ExperimentalTools" Visibility="Collapsed">
                 <MenuFlyoutSeparator />
                 <TextBlock Style="{StaticResource SectionTitle}">Experimental tools</TextBlock>

--- a/HDRImageViewerCS/MainPage.xaml
+++ b/HDRImageViewerCS/MainPage.xaml
@@ -120,12 +120,12 @@
             <TextBlock Style="{StaticResource InfoLine}"><Bold>H:</Bold> Toggle UI</TextBlock>
             <TextBlock Style="{StaticResource InfoLine}"><Bold>F, F11:</Bold> Toggle fullscreen</TextBlock>
             <TextBlock Style="{StaticResource InfoLine}"><Bold>Esc:</Bold> Exit fullscreen</TextBlock>
-            <TextBlock Style="{StaticResource InfoLine}"><Bold>G:</Bold> Toggle gamut constraints</TextBlock>
-            <TextBlock Style="{StaticResource InfoLine}"><Bold>P:</Bold> Toggle display profile override (SDR-only)</TextBlock>
             <StackPanel x:Name="ExperimentalTools" Visibility="Collapsed">
                 <MenuFlyoutSeparator />
                 <TextBlock Style="{StaticResource SectionTitle}">Experimental tools</TextBlock>
                 <TextBlock Style="{StaticResource InfoLine}">Press CTRL+F1 to turn off</TextBlock>
+                <TextBlock Style="{StaticResource InfoLine}"><Bold>G:</Bold> Toggle gamut constraints</TextBlock>
+                <TextBlock Style="{StaticResource InfoLine}"><Bold>P:</Bold> Toggle display profile override (SDR-only)</TextBlock>
                 <TextBlock>Override display MaxCLL:</TextBlock>
                 <Slider
                     x:Name="DispMaxCLLOverrideSlider"

--- a/HDRImageViewerCS/MainPage.xaml.cs
+++ b/HDRImageViewerCS/MainPage.xaml.cs
@@ -356,6 +356,10 @@ namespace HDRImageViewerCS
 
         private void ToggleGamutMap(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
+            if (!enableExperimentalTools) return;
+
+            if (WorkaroundShouldIgnoreAccelerator()) return;
+
             enableGamutMap = !enableGamutMap;
 
             UpdateRenderOptions();
@@ -365,6 +369,10 @@ namespace HDRImageViewerCS
 
         private void ToggleProfileOverride(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
+            if (!enableExperimentalTools) return;
+
+            if (WorkaroundShouldIgnoreAccelerator()) return;
+
             profileColorimetryOverride = !profileColorimetryOverride;
 
             ProfileOverride.Text = UIStrings.LABEL_PROFILEOVERRIDE + (profileColorimetryOverride ? "on (SDR only)" : "off");

--- a/HDRImageViewerCS/MainPage.xaml.cs
+++ b/HDRImageViewerCS/MainPage.xaml.cs
@@ -47,6 +47,8 @@ namespace HDRImageViewerCS
         bool isImageValid;
         bool isWindowVisible;
         bool enableExperimentalTools;
+        bool enableGamutMap = true;
+        bool profileColorimetryOverride = true;
         ImageLoaderOptions loaderOptions;
 
         ToolTip tooltip;
@@ -80,6 +82,8 @@ namespace HDRImageViewerCS
 
             currDispInfo.AdvancedColorInfoChanged += OnAdvancedColorInfoChanged;
             var acInfo = currDispInfo.GetAdvancedColorInfo();
+
+            currDispInfo.ColorProfileChanged += OnColorProfileChanged;
 
             swapChainPanel.CompositionScaleChanged += OnCompositionScaleChanged;
             swapChainPanel.SizeChanged += OnSwapChainPanelSizeChanged;
@@ -237,7 +241,8 @@ namespace HDRImageViewerCS
                     tm.Kind,
                     (float)SdrBrightnessFormatter.SliderToBrightness(BrightnessAdjustSlider.Value),
                     dispcll, // Display MaxCLL override
-                    dispInfo
+                    dispInfo,
+                    enableGamutMap
                     );
             }
         }
@@ -259,6 +264,10 @@ namespace HDRImageViewerCS
         }
 
         // Display state event handlers.
+        private void OnColorProfileChanged(DisplayInformation sender, object args)
+        {
+            UpdateDisplayACState(sender.GetAdvancedColorInfo());
+        }
 
         private void OnAdvancedColorInfoChanged(DisplayInformation sender, object args)
         {
@@ -343,6 +352,31 @@ namespace HDRImageViewerCS
             if (WorkaroundShouldIgnoreAccelerator()) return;
 
             SetExperimentalTools(!enableExperimentalTools);
+        }
+
+        private void ToggleGamutMap(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        {
+            enableGamutMap = !enableGamutMap;
+
+            UpdateRenderOptions();
+
+            Gamutmap.Text = UIStrings.LABEL_GAMUTMAP + (enableGamutMap ? "on" : "off");
+        }
+
+        private void ToggleProfileOverride(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        {
+            profileColorimetryOverride = !profileColorimetryOverride;
+
+            ProfileOverride.Text = UIStrings.LABEL_PROFILEOVERRIDE + (profileColorimetryOverride ? "on (SDR only)" : "off");
+
+            ScrapeColorProfile();
+
+            UpdateRenderOptions();
+        }
+
+        private void ScrapeColorProfile()
+        {
+
         }
 
         /// <summary>

--- a/HDRImageViewerCS/UIStrings.cs
+++ b/HDRImageViewerCS/UIStrings.cs
@@ -22,6 +22,8 @@ namespace HDRImageViewerCS
         public const string LABEL_MAXCLL               = "Estimated MaxCLL: ";
         public const string LABEL_NA                   = "N/A";
         public const string LABEL_MEDCLL               = "Estimated MedianCLL: ";
+        public const string LABEL_GAMUTMAP             = "Constrain image gamut: ";
+        public const string LABEL_PROFILEOVERRIDE      = "Override display colorimetry: ";
 
         public const string ERROR_DEFAULTTITLE         = "Unable to load image";
         public const string ERROR_INVALIDCMDARGS       = "Command line usage";


### PR DESCRIPTION
Add some basic toggle-able gamut mapping to prevent any output from being outside of the display's underlying gamut.