### PR TITLE
Fix build (NuGet packages problem)

### DIFF
--- a/DXRenderer/DXRenderer.vcxproj
+++ b/DXRenderer/DXRenderer.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.props" Condition="Exists('..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.props')" />
+  <Import Project="..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.props" Condition="Exists('..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -99,8 +99,8 @@
   <ImportGroup Label="Shared">
     <Import Project="..\packages\openexr-msvc14-x64.2.2.0.7784\build\native\OpenEXR-msvc14-x64.targets" Condition="Exists('..\packages\openexr-msvc14-x64.2.2.0.7784\build\native\OpenEXR-msvc14-x64.targets')" />
     <Import Project="..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-    <Import Project="..\packages\directxtex_uwp.2020.7.2.1\build\native\directxtex_uwp.targets" Condition="Exists('..\packages\directxtex_uwp.2020.7.2.1\build\native\directxtex_uwp.targets')" />
-    <Import Project="..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.targets" Condition="Exists('..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.targets')" />
+    <Import Project="..\packages\directxtex_uwp.2021.11.8.1\build\native\directxtex_uwp.targets" Condition="Exists('..\packages\directxtex_uwp.2021.11.8.1\build\native\directxtex_uwp.targets')" />
+    <Import Project="..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.targets" Condition="Exists('..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.targets')" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -495,8 +495,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\openexr-msvc14-x64.2.2.0.7784\build\native\OpenEXR-msvc14-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\openexr-msvc14-x64.2.2.0.7784\build\native\OpenEXR-msvc14-x64.targets'))" />
     <Error Condition="!Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-    <Error Condition="!Exists('..\packages\directxtex_uwp.2020.7.2.1\build\native\directxtex_uwp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_uwp.2020.7.2.1\build\native\directxtex_uwp.targets'))" />
-    <Error Condition="!Exists('..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.props'))" />
-    <Error Condition="!Exists('..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_uwp.2021.11.8.1\build\native\directxtex_uwp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_uwp.2021.11.8.1\build\native\directxtex_uwp.targets'))" />
+    <Error Condition="!Exists('..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.props'))" />
+    <Error Condition="!Exists('..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.targets'))" />
   </Target>
 </Project>

--- a/DXRenderer/packages.config
+++ b/DXRenderer/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxtex_uwp" version="2020.7.2.1" targetFramework="native" />
+  <package id="directxtex_uwp" version="2021.11.8.1" targetFramework="native" />
   <package id="openexr-msvc14-x64" version="2.2.0.7784" targetFramework="native" />
-  <package id="vcpkg-export-20210528-221932" version="1.0.0" targetFramework="native" />
+  <package id="vcpkg-export-20210804-195144" version="1.0.0" targetFramework="native" />
   <package id="zlib-msvc-x64" version="1.2.11.8900" targetFramework="native" />
 </packages>

--- a/HeifUtil/HeifUtil.vcxproj
+++ b/HeifUtil/HeifUtil.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.props" Condition="Exists('..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.props')" />
+  <Import Project="..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.props" Condition="Exists('..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -165,13 +165,13 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.targets" Condition="Exists('..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.targets')" />
+    <Import Project="..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.targets" Condition="Exists('..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.props'))" />
-    <Error Condition="!Exists('..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\vcpkg-export-20210528-221932.1.0.0\build\native\vcpkg-export-20210528-221932.targets'))" />
+    <Error Condition="!Exists('..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.props'))" />
+    <Error Condition="!Exists('..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\vcpkg-export-20210804-195144.1.0.0\build\native\vcpkg-export-20210804-195144.targets'))" />
   </Target>
 </Project>

--- a/HeifUtil/packages.config
+++ b/HeifUtil/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="vcpkg-export-20210528-221932" version="1.0.0" targetFramework="native" />
+  <package id="vcpkg-export-20210804-195144" version="1.0.0" targetFramework="native" />
 </packages>

--- a/UnitTests/UnitTests.vcxproj
+++ b/UnitTests/UnitTests.vcxproj
@@ -214,7 +214,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\openexr-msvc14-x64.2.2.0.7784\build\native\OpenEXR-msvc14-x64.targets" Condition="Exists('..\packages\openexr-msvc14-x64.2.2.0.7784\build\native\OpenEXR-msvc14-x64.targets')" />
     <Import Project="..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets" Condition="Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" />
-    <Import Project="..\packages\directxtex_uwp.2020.7.2.1\build\native\directxtex_uwp.targets" Condition="Exists('..\packages\directxtex_uwp.2020.7.2.1\build\native\directxtex_uwp.targets')" />
+    <Import Project="..\packages\directxtex_uwp.2021.11.8.1\build\native\directxtex_uwp.targets" Condition="Exists('..\packages\directxtex_uwp.2021.11.8.1\build\native\directxtex_uwp.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -222,6 +222,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\openexr-msvc14-x64.2.2.0.7784\build\native\OpenEXR-msvc14-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\openexr-msvc14-x64.2.2.0.7784\build\native\OpenEXR-msvc14-x64.targets'))" />
     <Error Condition="!Exists('..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-msvc-x64.1.2.11.8900\build\native\zlib-msvc-x64.targets'))" />
-    <Error Condition="!Exists('..\packages\directxtex_uwp.2020.7.2.1\build\native\directxtex_uwp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_uwp.2020.7.2.1\build\native\directxtex_uwp.targets'))" />
+    <Error Condition="!Exists('..\packages\directxtex_uwp.2021.11.8.1\build\native\directxtex_uwp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\directxtex_uwp.2021.11.8.1\build\native\directxtex_uwp.targets'))" />
   </Target>
 </Project>

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="directxtex_uwp" version="2020.7.2.1" targetFramework="native" />
+  <package id="directxtex_uwp" version="2021.11.8.1" targetFramework="native" />
   <package id="openexr-msvc14-x64" version="2.2.0.7784" targetFramework="native" />
   <package id="zlib-msvc-x64" version="1.2.11.8900" targetFramework="native" />
 </packages>


### PR DESCRIPTION
nuget would refuse to download any missing packages as it couldn't find vcpkg-export-20210528-221932. I had to manually edit all the project files with the most recent version I could find to be able to even start a build. The DX package is likely unnecessary, but I just updated everything.
You can reproduce the issue by just starting from a clean repository downloaded from github. I used VS2022 but it shouldn't make a difference.

Now I have another problem... I'm really not the most experienced with nuget packages and using vcpkg or linked git repositories.
I've followed the instructions at https://github.com/13thsymphony/HDRImageViewer/blob/csappv2/libheif-vcpkg/readme.md but they don't seem to work, like, it seems some steps after that are missing? like manually asking vcpkg to download and build the heif repository? Because if I do try to start a build, this is the error I get:
```Cannot open include file: 'libheif/heif.h': No such file or directory``` (from pch.h in both DXRenderer and HeifUtil).

My objective was to fix some jxr files (Windows Gaming Bar HDR screenshots) that fail to open, while other work, for what seem like no reason. So I wanted to try and find the failure point and possibly fix it.