### PR TITLE
Fix large images still not being openable

### DIFF
--- a/DXRenderer/HDRImageViewerRenderer.cpp
+++ b/DXRenderer/HDRImageViewerRenderer.cpp
@@ -912,14 +912,22 @@ void HDRImageViewerRenderer::ComputeHdrMetadata()
 
     ctx->DrawImage(m_histogramEffect.Get());
 
-    // We ignore D2DERR_RECREATE_TARGET here. This error indicates that the device
-    // is lost. It will be handled during the next call to Present.
-    HRESULT hr = ctx->EndDraw();
-    ctx->SetDpi(m_deviceResources->GetDpi(), m_deviceResources->GetDpi());
-    if (hr != D2DERR_RECREATE_TARGET)
+    // Depending on the resolution, DPI, Windows size etc,
+    // EndDraw() might return the "D1225: Tile Too Small" error.
+    // In that case, we want to continue, even if we won't have the histogram data.
+    try
     {
-        IFT(hr);
+        HRESULT hr = ctx->EndDraw();
+        // We ignore D2DERR_RECREATE_TARGET here. This error indicates that the device
+        // is lost. It will be handled during the next call to Present.
+        if (FAILED(hr) && hr != D2DERR_RECREATE_TARGET)
+        {
+            throw Platform::Exception::CreateException(hr);
+        }
     }
+    catch (...) { }
+
+    ctx->SetDpi(m_deviceResources->GetDpi(), m_deviceResources->GetDpi());
 
     float *histogramData = new float[sc_histNumBins];
     IFT(m_histogramEffect->GetValue(D2D1_HISTOGRAM_PROP_HISTOGRAM_OUTPUT,


### PR DESCRIPTION
5120x1440 jxr HDR images fail to be opened when the app is in a maxed out window, because the histogram still fails to draw (```EndDraw()``` has an exception within itself, and returns error ```D1225```). I haven't really spent much time analyzing how the histogram is used, but I have found that the jxr image is visualized exactly the same way whether the ```EndDraw()``` failed or not (thus the max luminance (CLL) remains n/a). I can manage to open these images, but only if the app started in a small window. If it's maxed out, it will throw the error.

I'm on the latest version of Win 11 and have a recent high end Nvidia card (I don't think it matters). My resolution is set to 5120x1440 and DPI to 100% (so 96).

I have found that changing the ```SetDpi()``` call from 96 to 1 avoids the exception to be throw, though it actually kind of breaks the final image rendering and the max luminance value. I know that makes no sense, I was just messing around.

Before the code was changed to add the ```SetDpi()``` workaround (from @imbushuo), it errored out even more often, though I'm not sure exactly what improved.

This is unrelated to this PR, but I also noticed the max luminance calculated by the app depends on the window size. You can test it by making the window tiny and opening the same image multiple times.
I suppose the histogram is rendered in a way that depends on the window size, while it shouldn't? 